### PR TITLE
Adds support for additional arguments in TailwindHostedService

### DIFF
--- a/Tailwind.Extensions.AspNetCore.sln.DotSettings.user
+++ b/Tailwind.Extensions.AspNetCore.sln.DotSettings.user
@@ -1,9 +1,9 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003ADefaultInterpolatedStringHandler_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003FAppData_003FRoaming_003FJetBrains_003FRider2025_002E2_003Fresharper_002Dhost_003FSourcesCache_003Fc1c946eaa6d8ddaaea1b63e936ca8ed2791d9316c5b025a41d445891e8a59ecd_003FDefaultInterpolatedStringHandler_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=47796ad6_002D76b8_002D433b_002Da5ef_002D65e0598f0b93/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="MissingOptionsThrowsError" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=47796ad6_002D76b8_002D433b_002Da5ef_002D65e0598f0b93/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="MissingOptionsThrowsError" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Project Location="C:\Users\hilto\RiderProjects\Tailwind.Extensions.AspNetCore\src\Tailwind.Extensions.AspNetCore.Tests" Presentation="&amp;lt;Tailwind.Extensions.AspNetCore.Tests&amp;gt;" /&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=7ce84f90_002D6ae2_002D4e9e_002D860e_002Deb90f45871f3/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Junie Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=7ce84f90_002D6ae2_002D4e9e_002D860e_002Deb90f45871f3/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Junie Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Namespace&gt;Tailwind.Extensions.AspNetCore.Tests&lt;/Namespace&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
 	</wpf:ResourceDictionary>

--- a/src/Tailwind.Extensions.AspNetCore.Tests/TailwindCliHostedServiceTests.cs
+++ b/src/Tailwind.Extensions.AspNetCore.Tests/TailwindCliHostedServiceTests.cs
@@ -53,4 +53,29 @@ public class TailwindCliHostedServiceTests
 
         A.CallTo(() => tailwindProcess.StartProcess(expectedCliPath,A<string>.Ignored)).MustHaveHappened();
     }
+
+    [Fact]
+    public async Task AdditionalArgumentsAreIncludedInProcessStart()
+    {
+        var tailwindOptions = new TailwindOptions
+        {
+            InputFile = "input.css",
+            OutputFile = "output.css",
+            TailwindCliPath = null,
+            AdditionalArguments = "--verbose"
+        };
+        var options = Options.Create(tailwindOptions);
+        var tailwindProcess = A.Fake<ITailwindProcessInterop>();
+        var hostEnvironment = A.Fake<IHostEnvironment>();
+        var logger = A.Fake<ILogger<TailwindHostedService>>();
+
+        A.CallTo(() => hostEnvironment.EnvironmentName).Returns(Environments.Development);
+
+        var tailwindHostedService = new TailwindHostedService(options, hostEnvironment, tailwindProcess, logger);
+        await tailwindHostedService.StartAsync(CancellationToken.None);
+
+        A.CallTo(() => tailwindProcess.StartProcess(
+            A<string>.Ignored,
+            A<string>.That.Contains("--verbose"))).MustHaveHappened();
+    }
 }

--- a/src/Tailwind.Extensions.AspNetCore/TailwindHostedService.cs
+++ b/src/Tailwind.Extensions.AspNetCore/TailwindHostedService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,6 +10,7 @@ public class TailwindOptions
     public string? InputFile { get; set; }
     public string? OutputFile { get; set; }
     public string? TailwindCliPath { get; set; }
+    public string AdditionalArguments { get; set; } = string.Empty;
 }
 
 /// <summary>
@@ -42,17 +42,22 @@ public class TailwindHostedService : IHostedService, IDisposable
         if (!_hostEnvironment.IsDevelopment())
             return Task.CompletedTask;
 
-
         var input = _options.InputFile;
         var output = _options.OutputFile;
 
         Guard.AgainstNull(input, "check Tailwind configuration");
         Guard.AgainstNull(output, "check Tailwind configuration");
 
-        _logger.LogInformation($"tailwind -i {input} -o {output} --watch");
+        var args = $"-i {input} -o {output} --watch";
+        if (!string.IsNullOrEmpty(_options.AdditionalArguments))
+        {
+            args += $" {_options.AdditionalArguments}";
+        }
+
+        _logger.LogInformation($"tailwind {args}");
 
         var processName = string.IsNullOrEmpty(_options.TailwindCliPath) ? "tailwind" : _options.TailwindCliPath;
-        _process = _tailwindProcess.StartProcess(processName, $"-i {input} -o {output} --watch");
+        _process = _tailwindProcess.StartProcess(processName, args);
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
This pull request adds support for passing additional arguments to the Tailwind CLI process and improves test coverage to ensure these arguments are handled correctly. The main changes include updating the `TailwindOptions` class, modifying the hosted service to use the new option, and adding a new test.

**Feature: Support for additional Tailwind CLI arguments**
- Added a new property `AdditionalArguments` to the `TailwindOptions` class, allowing users to specify extra command-line arguments for the Tailwind CLI.
- Updated the `TailwindHostedService` to append `AdditionalArguments` to the CLI invocation if provided, ensuring they are included when starting the process.

**Testing:**
- Added a new unit test `AdditionalArgumentsAreIncludedInProcessStart` to verify that any additional arguments specified in `TailwindOptions` are correctly passed to the process.

**Code cleanup:**
- Removed an unused `using Microsoft.Extensions.Configuration;` directive from `TailwindHostedService.cs`.

**Minor:**
- Updated user settings in `.DotSettings.user` file to toggle session activity flags for unit test sessions.